### PR TITLE
Added support for SPM with Xcode 13.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "DecibelCore",
-            targets: ["DecibelSDK"]
+            targets: ["DecibelCore"]
         )
     ],
     dependencies: [
@@ -20,7 +20,7 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .binaryTarget(
-            name: "DecibelSDK",
+            name: "DecibelCore",
             path: "DecibelCore.xcframework"
         )
     ]


### PR DESCRIPTION
Adding Decibel as swift package in Xcode 13.3 results in an error and inability to resolve the package.
Error in question is `artifact not found for target 'DecibelSDK'`.
According to this[ stackoverflow response ](https://stackoverflow.com/a/71546817/4189037), from Xcode 13.3, "The artifact name has to match the target name"
